### PR TITLE
fix: corrected orgs in MAINTAINERS

### DIFF
--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,7 +1,7 @@
 | Org                    | Name                   | GitHub Username             |
 | -----------------------| -----------------------|-----------------------------|
-| 5GFF| Kevin Smith | Kevsy |  
-| 5GFF | Mahesh Chapalamadugu | maheshc01 |
+| Vodafone| Kevin Smith | Kevsy |  
+| Verizon | Mahesh Chapalamadugu | maheshc01 |
 | Capgemini | Deepak Gunjal | gunjald |
 | Telefonica | Jose Manuel Conde Gómez | JoseMConde |
 | EdgeXR | Jon Gainsley | gainsley |


### PR DESCRIPTION
5GFF removed and replaced with Maintainer's orgs.

#### What type of PR is this?

Add one of the following kinds:
* repository management



#### What this PR does / why we need it:

Incorrect orgs in MAINTAINERS table.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #7 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
