### PR TITLE
chore(api): update version references from wip to 0.1.0-alpha.1

### DIFF
--- a/code/API_definitions/edge-application-management.yaml
+++ b/code/API_definitions/edge-application-management.yaml
@@ -2,7 +2,7 @@
 openapi: 3.0.3
 info:
   title: Edge Application Management API
-  version: wip
+  version: 0.1.0-alpha.1
   description: |
     Edge Application Management API allows API consumers to manage the
     Life Cycle of an Application and to Discover Edge Cloud Zones.
@@ -163,7 +163,7 @@ externalDocs:
   url: https://github.com/camaraproject/EdgeCloud
 
 servers:
-  - url: "{apiRoot}/edge-application-management/vwip"
+  - url: "{apiRoot}/edge-application-management/v0.1.0-alpha.1"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/edge-cloud-eam-createAppDeployment.feature
+++ b/code/Test_definitions/edge-cloud-eam-createAppDeployment.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation createAppDeployment
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation createAppDeployment
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppDeplo
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common createAppDeployment setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/deployments"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/deployments"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-createAppInstance.feature
+++ b/code/Test_definitions/edge-cloud-eam-createAppInstance.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation createAppInstance
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation createAppInstance
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppInsta
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common createAppInstance setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/appinstances"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/appinstances"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-deleteApp.feature
+++ b/code/Test_definitions/edge-cloud-eam-deleteApp.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation deleteApp
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation deleteApp
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteApp
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common deleteApp setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/apps/{appId}"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/apps/{appId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-deleteAppDeployment.feature
+++ b/code/Test_definitions/edge-cloud-eam-deleteAppDeployment.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppDeployment
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation deleteAppDeployment
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppDeplo
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common deleteAppDeployment setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/deployment/{appDeploymentId}"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/deployment/{appDeploymentId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-deleteAppInstance.feature
+++ b/code/Test_definitions/edge-cloud-eam-deleteAppInstance.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppInstance
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation deleteAppInstance
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppInsta
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common deleteAppInstance setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/appinstances"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/appinstances"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-getApp.feature
+++ b/code/Test_definitions/edge-cloud-eam-getApp.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation getApp
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation getApp
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -12,7 +12,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getApp
 
   Background: Common getApp setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/apps/{appId}"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/apps/{appId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-getAppDeployments.feature
+++ b/code/Test_definitions/edge-cloud-eam-getAppDeployments.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation getAppDeployments
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation getAppDeployments
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppDeployme
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common getAppDeployments setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/deployments"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/deployments"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-getAppInstance.feature
+++ b/code/Test_definitions/edge-cloud-eam-getAppInstance.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation getAppInstance
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common getAppInstance setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/appinstances"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/appinstances"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-getApps.feature
+++ b/code/Test_definitions/edge-cloud-eam-getApps.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operations getApps
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operations getApps
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operations getApps
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common getApps setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/apps"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/apps"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-getClusters.feature
+++ b/code/Test_definitions/edge-cloud-eam-getClusters.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation getClusters
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation getClusters
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getClusters
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common getClusters setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/clusters"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/clusters"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-getEdgeCloudZones.feature
+++ b/code/Test_definitions/edge-cloud-eam-getEdgeCloudZones.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZones
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation getEdgeCloudZones
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common getEdgeCloudZones setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/edge-cloud-zones"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/edge-cloud-zones"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-submitApp.feature
+++ b/code/Test_definitions/edge-cloud-eam-submitApp.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation submitApp
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation submitApp
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation submitApp
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common submitApp setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/apps"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/apps"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-cloud-eam-updateAppDeployment.feature
+++ b/code/Test_definitions/edge-cloud-eam-updateAppDeployment.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation updateAppDeployment
+Feature: CAMARA Edge Application Management API, v0.1.0-alpha.1 - Operation updateAppDeployment
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation updateAppDeplo
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common updateAppDeployment setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/deployment/{appDeploymentId}"
+    And the resource "/edge-application-management/v0.1.0-alpha.1/deployment/{appDeploymentId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

Updates all version references from `wip` to `0.1.0-alpha.1` across the API definition and test feature files to prepare for the first alpha release.

Changes include:
- `version: wip` → `version: 0.1.0-alpha.1` in the OpenAPI spec
- `vwip` → `v0.1.0-alpha.1` in all server URL paths and test resource paths
- 14 files updated (1 API definition + 13 test definitions)

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Straightforward find-and-replace across all files. No logic changes.

#### Changelog input

```
release-note
Update API version from wip to 0.1.0-alpha.1
```

#### Additional documentation

This section can be blank.

```
docs

```