### PR TITLE
Mark credential fields as writeOnly in EAM schema

### DIFF
--- a/code/API_definitions/edge-application-management.yaml
+++ b/code/API_definitions/edge-application-management.yaml
@@ -1149,7 +1149,8 @@ components:
                 Access Token granting access to the POST operation to create
                 notification
               type: string
-              maxLength: 8192
+              writeOnly: true
+              maxLength: 4096
             accessTokenExpiresUtc:
               type: string
               format: date-time
@@ -1501,6 +1502,7 @@ components:
             credentials:
               type: string
               maxLength: 2048
+              writeOnly: true
               description: |
                 Password or personal access token created by
                 developer to acces the app repository. API users can generate


### PR DESCRIPTION
#### What type of PR is this?

  correction

  #### What this PR does / why we need it:

  Marks two credential-carrying fields as `writeOnly: true` so the OpenAPI
  spec explicitly documents they must never be returned in a response body:

  - `AppManifest.appRepo.credentials` — password/personal access token used
    to access the app image repository. Without `writeOnly`, nothing in the
    spec prevented this value from leaking in `getApps` / `getApp` responses.
  - `AccessTokenCredential.accessToken` — notification access token. `writeOnly`
    had been dropped and `maxLength` widened to `8192` with no stated reason.
    This restores `writeOnly: true` and reverts `maxLength` to `4096` to match
    the canonical schema in Commonalities (`CAMARA_event_common.yaml`).

  #### Which issue(s) this PR fixes:

  Fixes #47

  #### Special notes for reviewers:

  No behavioral/runtime change — this only tightens the API contract
  (`writeOnly` + `maxLength`) to align with the CAMARA Design Guide expectation
  that credential material is write-only, and with the canonical Commonalities
  `AccessTokenCredential` schema.

  #### Changelog input


release-note Mark AppManifest.appRepo.credentials and AccessTokenCredential.accessToken as writeOnly; restore
accessToken maxLength to 4096 to match Commonalities.


  #### Additional documentation

  This section can be blank.

```
docs

```
