### PR TITLE
Fix HTTP status codes to match Design Guide semantics (#48)

### DIFF
--- a/code/API_definitions/edge-application-management.yaml
+++ b/code/API_definitions/edge-application-management.yaml
@@ -256,8 +256,6 @@ paths:
                 message: "App already exists"
         "500":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
-        "501":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic501"
         "503":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic503"
     get:
@@ -390,7 +388,7 @@ paths:
                 $ref: "#/components/schemas/ErrorInfo"
               example:
                 status: 409
-                code: ABORTED
+                code: INCOMPATIBLE_STATE
                 message: "App with a running application instance cannot be deleted"
         "500":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
@@ -469,8 +467,6 @@ paths:
                 message: "Application already instantiated in the given Edge Cloud Zone"
         "500":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
-        "501":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic501"
         "503":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic503"
       callbacks:
@@ -661,8 +657,6 @@ paths:
                 message: "Deployment already exists"
         "500":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
-        "501":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic501"
         "503":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic503"
       callbacks:
@@ -722,8 +716,8 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
-        "410":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic410"
+        "404":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "500":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
         "503":
@@ -765,8 +759,6 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-        "410":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic410"
         "500":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
         "503":
@@ -884,8 +876,6 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-        "410":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic410"
         "409":
           description: Conflict
           content:


### PR DESCRIPTION
#### What type of PR is this?

  correction

  #### What this PR does / why we need it:

  Aligns three error-code choices in the EAM API with the semantics defined
  in the CAMARA API Design Guide (section 3.2.1):

  - **`deleteApp` (`DELETE /apps/{appId}`)**: changes the `409` code from
    `ABORTED` to `INCOMPATIBLE_STATE`. `ABORTED` is defined for
    concurrent-modification conflicts, but this case — a delete blocked
    because a referenced running instance still exists — matches
    `INCOMPATIBLE_STATE` instead.
  - **`/deployments` CRUD operations**: removes `410 GONE` from
    `getAppDeployments` (GET), `deleteAppDeployment` (DELETE) and
    `updateAppDeployment` (PATCH). The Design Guide and this API's own
    `Generic410` response template scope `410` to the notification/callback
    flow only (correctly used by `onAppInstanceStatusChange` and
    `onAppDeploymentStatusChange`, left untouched). `GET /deployments` now
    uses `404` for the no-match case (previously had neither); `DELETE`/`PATCH`
    already declared `404`, so the redundant `410` was simply dropped.
  - **`submitApp`, `createAppInstance`, `createAppDeployment`**: removes
    `501 NOT_IMPLEMENTED`. The Design Guide says `501` usage should be
    avoided and reserved for genuinely optional endpoints; none of these
    three creation operations state a justification for being optional.

  #### Which issue(s) this PR fixes:

  Fixes #48

  #### Special notes for reviewers:

  No runtime/behavioral change — this only corrects which error codes are
  documented in the spec to align with the Design Guide's standardized
  error-response semantics. Callback `410` usage (notification flow) was
  intentionally left as-is since it already matches the Guide.

  #### Changelog input


release-note Fix deleteApp 409 code (ABORTED to INCOMPATIBLE_STATE), remove 410 from plain /deployments CRUD operations,
and remove unjustified 501 from creation operations, per Design Guide error-response semantics.


  #### Additional documentation

  This section can be blank.


docs
