### PR TITLE
Fix resource modelling inconsistencies across apps/instances/deployments (#49)

### DIFF
--- a/code/API_definitions/edge-application-management.yaml
+++ b/code/API_definitions/edge-application-management.yaml
@@ -503,15 +503,6 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/AppId"
-        - name: appInstanceId
-          description: |
-            A globally unique identifier associated with a running
-            instance of an application within an specific Edge Cloud Zone.
-            Edge Cloud Provider generates this identifier.
-          in: query
-          required: false
-          schema:
-            $ref: "#/components/schemas/AppInstanceId"
         - name: region
           description: |
             Human readable name of the geographical Edge Cloud Region of
@@ -749,15 +740,6 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/AppId"
-        - name: appDeploymentId
-          description: |
-            A globally unique identifier associated with a existing deployment
-            of an application. Edge Cloud Platform generates this identifier when
-            the deployment request in the Edge Cloud Zone is successful.
-          in: query
-          required: false
-          schema:
-            $ref: "#/components/schemas/AppDeploymentId"
       responses:
         "200":
           description: |

--- a/code/API_definitions/edge-application-management.yaml
+++ b/code/API_definitions/edge-application-management.yaml
@@ -69,7 +69,9 @@ info:
     an instance of an application in a given Edge Cloud Zone,
     if this parameter is not set, the Edge Cloud Provider will instantiate
     the applications in all the Edge Cloud Zones.
-    * __getAppInstance__  Retrieves the list with information of the instances
+    * __getAppInstance__ - Retrieves the information of a given application
+    instance.
+    * __getAppInstances__  Retrieves the list with information of the instances
     related to a given application.
     * __deleteAppInstance__ - Removes a given application instance from an Edge
     Cloud Zone.
@@ -77,6 +79,8 @@ info:
     __Application Deployment Management__
     * __createAppDeployment__ - Requests the Edge Cloud Provider to create and
     maintain application instances to multiple Edge Cloud Zones.
+    * __getAppDeployment__ - Retrieves the information of a given application
+    deployment.
     * __getAppDeployments__ - Retrieves a list of deployments for a given
     application.
     * __deleteAppDeployment__ - Terminates a specific application deployment,
@@ -285,7 +289,7 @@ paths:
                 type: array
                 maxItems: 100
                 items:
-                  $ref: "#/components/schemas/AppManifest"
+                  $ref: "#/components/schemas/AppManifestInfo"
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
@@ -329,10 +333,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  appManifest:
-                    $ref: "#/components/schemas/AppManifest"
+                $ref: "#/components/schemas/AppManifestInfo"
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
@@ -397,7 +398,7 @@ paths:
         "503":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic503"
 
-  /appinstances:
+  /app-instances:
     post:
       security:
         - openId:
@@ -441,7 +442,10 @@ paths:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
             Location:
-              description: Contains the URI of the newly created application.
+              description: |
+                Contains the URI of the newly created application instance,
+                as returned by the getAppInstance operation
+                (GET /app-instances/{appInstanceId}).
               required: true
               schema:
                 type: string
@@ -486,7 +490,7 @@ paths:
       description: |
         Ask the Edge Cloud Provider the information of the instances for a
         given application
-      operationId: getAppInstance
+      operationId: getAppInstances
       parameters:
         - $ref: "#/components/parameters/x-correlator"
         - name: appId
@@ -542,7 +546,51 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
         "503":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic503"
-  /appinstances/{appInstanceId}:
+  /app-instances/{appInstanceId}:
+    get:
+      security:
+        - openId:
+            - edge-application-management:instances:read
+      tags:
+        - Application
+      summary: Retrieve the information of an Application Instance
+      description: |
+        Ask the Edge Cloud Provider the information for a given application
+        instance
+      operationId: getAppInstance
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+        - name: appInstanceId
+          description: |
+            A globally unique identifier associated with a running
+            instance of an application within an specific Edge Cloud Zone.
+            Edge Cloud Provider generates this identifier.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/AppInstanceId"
+      responses:
+        "200":
+          description: Information of the Application Instance
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppInstanceInfo"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
+        "401":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
+        "403":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
+        "404":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
+        "500":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
+        "503":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic503"
     delete:
       security:
         - openId:
@@ -636,6 +684,16 @@ paths:
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
+            Location:
+              description: |
+                Contains the URI of the newly created application deployment,
+                as returned by the getAppDeployment operation
+                (GET /deployments/{appDeploymentId}).
+              required: true
+              schema:
+                type: string
+                format: uri
+                maxLength: 2048
           content:
             application/json:
               schema:
@@ -729,6 +787,50 @@ paths:
         "503":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic503"
   /deployments/{appDeploymentId}:
+    get:
+      security:
+        - openId:
+            - edge-application-management:deployments:read
+      tags:
+        - Application
+      summary: Retrieve the information of an Application Deployment
+      description: |
+        Ask the Edge Cloud Provider the information of a given application
+        deployment
+      operationId: getAppDeployment
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+        - name: appDeploymentId
+          description: |
+            A globally unique identifier associated with a existing deployment
+            of an application. Edge Cloud Platform generates this identifier when
+            the deployment request in the Edge Cloud Zone is successful.
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/AppDeploymentId"
+      responses:
+        "200":
+          description: Information of the Application Deployment
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppDeploymentInfo"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
+        "401":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
+        "403":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
+        "404":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
+        "500":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic500"
+        "503":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic503"
     delete:
       security:
         - openId:
@@ -1445,8 +1547,6 @@ components:
         Application information and requirements provided by the
         Application Provider
       properties:
-        appId:
-          $ref: "#/components/schemas/AppId"
         name:
           type: string
           maxLength: 64
@@ -1611,6 +1711,20 @@ components:
         - appRepo
         - requiredResources
         - componentSpec
+
+    AppManifestInfo:
+      description: |
+        Application information as returned by the Edge Cloud Provider,
+        including the appId assigned once the application has been
+        submitted.
+      allOf:
+        - $ref: "#/components/schemas/AppManifest"
+        - type: object
+          required:
+            - appId
+          properties:
+            appId:
+              $ref: "#/components/schemas/AppId"
 
     AppProvider:
       type: string

--- a/code/Test_definitions/edge-application-management-createAppInstance.feature
+++ b/code/Test_definitions/edge-application-management-createAppInstance.feature
@@ -11,7 +11,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppInsta
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common createAppInstance setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/appinstances"
+    And the resource "/edge-application-management/vwip/app-instances"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-application-management-deleteAppInstance.feature
+++ b/code/Test_definitions/edge-application-management-deleteAppInstance.feature
@@ -11,7 +11,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppInsta
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common deleteAppInstance setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/appinstances"
+    And the resource "/edge-application-management/vwip/app-instances"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/edge-application-management-getApp.feature
+++ b/code/Test_definitions/edge-application-management-getApp.feature
@@ -27,7 +27,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getApp
     Then response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with the OAS schema at "/components/schemas/AppManifest"
+    And the response body complies with the OAS schema at "/components/schemas/AppManifestInfo"
     And the response property "$name" has the value provided for submitApp
     And the response property "$appProvider" has the value provided for submitApp
     And the response property "$version" has the value provided for submitApp

--- a/code/Test_definitions/edge-application-management-getAppDeployment.feature
+++ b/code/Test_definitions/edge-application-management-getAppDeployment.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
+Feature: CAMARA Edge Application Management API, vwip - Operation getAppDeployment
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -6,35 +6,34 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
   #
   # Testing assets:
   # * An appId of a submitted application and the values used in the submitApp operation.
-  # * An Application instantiated by createAppInstance operation
+  # * A deployment instantiated by createAppDeployment operation
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
-  Background: Common getAppInstance setup
+  Background: Common getAppDeployment setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/app-instances/{appInstanceId}"
+    And the resource "/edge-application-management/vwip/deployments/{appDeploymentId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
   # Success scenarios
-  @eam_getAppInstance_01_generic_success_scenario
-  Scenario: Get information of an existing application instance
-    Given there is an application instance created by operation createAppInstance
-    And the path parameter "$.appInstanceId" is set to a valid application instance ID
-    When the request "getAppInstance" is sent
+  @eam_getAppDeployment_01_generic_success_scenario
+  Scenario: Get information of an existing application deployment
+    Given there is an application deployment created by operation createAppDeployment
+    And the path parameter "$.appDeploymentId" is set to a valid application deployment ID
+    When the request "getAppDeployment" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
-    And the response property "$name" has the value provided for createAppInstance
-    And the response property "$appId" has the value provided for createAppInstance
-    And the response property "$appInstanceId" has the value provided for createAppInstance and used as path parameter
-    And the response property "$appProvider" has the value provided for createAppInstance
-    And the response property "$edgeCloudZoneId" has the value provided for createAppInstance
+    And the response body complies with the OAS schema at "/components/schemas/AppDeploymentInfo"
+    And the response property "$appDeploymentName" has the value provided for createAppDeployment
+    And the response property "$appId" has the value provided for createAppDeployment
+    And the response property "$appDeploymentId" has the value provided for createAppDeployment and used as path parameter
+    And the response property "$edgeCloudZones" has the value provided for createAppDeployment
   # Errors
   # Error 404
-  @eam_getAppInstance_404.1_not_found
-  Scenario: Get information of a non-existing application instance
-    Given the path parameter "$.appInstanceId" is set to an invalid application instance ID
-    When the request "getAppInstance" is sent
+  @eam_getAppDeployment_404.1_not_found
+  Scenario: Get information of a non-existing application deployment
+    Given the path parameter "$.appDeploymentId" is set to an invalid application deployment ID
+    When the request "getAppDeployment" is sent
     Then the response status code is 404
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -42,10 +41,10 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
   # Error 403
-  @eam_getAppInstance_403.1_missing_access_token_scope
+  @eam_getAppDeployment_403.1_missing_access_token_scope
   Scenario: Missing access token scope
     Given the header "Authorization" is set to an access token that does not include the required scope
-    When the request "getAppInstance" is sent
+    When the request "getAppDeployment" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/edge-application-management-getAppDeployments.feature
+++ b/code/Test_definitions/edge-application-management-getAppDeployments.feature
@@ -34,35 +34,9 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppDeployme
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And information of all existing app deployments of given app is returned
     And the response body complies with the OAS schema at "/components/schemas/AppDeploymentInfo"
-  @eam_getAppDeployments_03_success_scenario_filtered_by_appInstanceId
-  Scenario: Get application deployments info with mandatory parameter ("appInstanceId")
-    Given there are application deployments created by operation createAppInstance
-    And the request path parameter "$.appInstanceId" is set to a valid application ID
-    When the request "getAppDeployments" is sent
-    Then the response status code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And information of all existing app deployments of given app is returned
-    And the response body complies with the OAS schema at "/components/schemas/AppDeploymentInfo"
-    And the response property "$name" has the value provided for createAppInstance
-    And the response property "$appId" has the value provided for createAppInstance
-    And the response property "$appInstanceId" has the value provided for createAppInstance and used as path parameter
-    And the response property "$appProvider" has the value provided for createAppInstance
-    And the response property "$edgeCloudZoneId" has the value provided for createAppInstance
   # Errors
   # Error 404
-  @eam_getAppDeployments_404.1_not_found_filtered_by_appInstanceId
-  Scenario: Get a list of application deployments info with a non-existing appInstanceId
-    Given there are running deployments of the app
-    And the path parameter "$.appInstanceId" is set to an invalid application instance ID
-    When the request "getAppDeployments" is sent
-    Then the response status code is 404
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response property "$.status" is 404
-    And the response property "$.code" is "NOT_FOUND"
-    And the response property "$.message" contains a user friendly text
-  @eam_getAppDeployments_404.2_not_found_filtered_by_appId
+  @eam_getAppDeployments_404.1_not_found_filtered_by_appId
   Scenario: Get a list of application deployments info with a non-existing appId
     Given the path parameter "appId" is set to a random UUID
     When the request "getAppDeployments" is sent

--- a/code/Test_definitions/edge-application-management-getAppInstances.feature
+++ b/code/Test_definitions/edge-application-management-getAppInstances.feature
@@ -34,22 +34,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And information of all existing app instances of given app is returned
     And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
-  @eam_getAppInstances_03_success_scenario_filtered_by_appInstanceId
-  Scenario: Get application instances info with mandatory parameter ("appInstanceId")
-    Given there are application instances created by operation createAppInstance
-    And the request path parameter "$.appInstanceId" is set to a valid application ID
-    When the request "getAppInstances" is sent
-    Then the response status code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And information of all existing app instances of given app is returned
-    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
-    And the response property "$name" has the value provided for createAppInstance
-    And the response property "$appId" has the value provided for createAppInstance
-    And the response property "$appInstanceId" has the value provided for createAppInstance and used as path parameter
-    And the response property "$appProvider" has the value provided for createAppInstance
-    And the response property "$edgeCloudZoneId" has the value provided for createAppInstance
-  @eam_getAppInstances_04_success_scenario_filtered_by_region
+  @eam_getAppInstances_03_success_scenario_filtered_by_region
   Scenario: Get application instances info with mandatory parameter ("region")
     Given there are application instances created by operation createAppInstance
     And the request path parameter "$.region" is set to a valid application ID
@@ -61,18 +46,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
     And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
   # Errors
   # Error 404
-  @eam_getAppInstances_404.1_not_found_filtered_by_appInstanceId
-  Scenario: Get a list of application instances info with a non-existing appInstanceId
-    Given there are running instances of the app
-    And the path parameter "$.appInstanceId" is set to an invalid application instance ID
-    When the request "getAppInstances" is sent
-    Then the response status code is 404
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response property "$.status" is 404
-    And the response property "$.code" is "NOT_FOUND"
-    And the response property "$.message" contains a user friendly text
-  @eam_getAppInstances_404.2_not_found_filtered_by_appId
+  @eam_getAppInstances_404.1_not_found_filtered_by_appId
   Scenario: Get a list of application instances info with a non-existing appId
     Given the path parameter "appId" is set to a random UUID
     When the request "getAppInstances" is sent

--- a/code/Test_definitions/edge-application-management-getAppInstances.feature
+++ b/code/Test_definitions/edge-application-management-getAppInstances.feature
@@ -1,0 +1,95 @@
+Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstances
+  # Input to be provided by the implementation to the tester
+  #
+  # Implementation indications:
+  # * apiRoot: API root of the server URL
+  #
+  # Testing assets:
+  # * An appId of a submitted application and the values used in the submitApp operation.
+  # * An Application instantiated by createAppInstance operation
+  # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
+  Background: Common getAppInstances setup
+    Given an environment at "apiRoot"
+    And the resource "/edge-application-management/vwip/app-instances"
+    And the header "Content-Type" is set to "application/json"
+    And the header "Authorization" is set to a valid access token
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+  # Success scenarios
+  @eam_getAppInstances_01_generic_success_scenario
+  Scenario: Get information of all existing application instances
+    Given there are application instances created by operation createAppInstance
+    When the request "getAppInstances" is sent
+    Then the response status code is 200
+    And A list of existing app instances is returned
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+  @eam_getAppInstances_02_success_scenario_filtered_by_appId
+  Scenario: Get application instances info with mandatory parameter ("appId")
+    Given there are application instances created by operation createAppInstance
+    And the request path parameter "$.appId" is set to a valid application ID
+    When the request "getAppInstances" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And information of all existing app instances of given app is returned
+    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+  @eam_getAppInstances_03_success_scenario_filtered_by_appInstanceId
+  Scenario: Get application instances info with mandatory parameter ("appInstanceId")
+    Given there are application instances created by operation createAppInstance
+    And the request path parameter "$.appInstanceId" is set to a valid application ID
+    When the request "getAppInstances" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And information of all existing app instances of given app is returned
+    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+    And the response property "$name" has the value provided for createAppInstance
+    And the response property "$appId" has the value provided for createAppInstance
+    And the response property "$appInstanceId" has the value provided for createAppInstance and used as path parameter
+    And the response property "$appProvider" has the value provided for createAppInstance
+    And the response property "$edgeCloudZoneId" has the value provided for createAppInstance
+  @eam_getAppInstances_04_success_scenario_filtered_by_region
+  Scenario: Get application instances info with mandatory parameter ("region")
+    Given there are application instances created by operation createAppInstance
+    And the request path parameter "$.region" is set to a valid application ID
+    When the request "getAppInstances" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And information of all existing app instances running in the specified region is returned
+    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+  # Errors
+  # Error 404
+  @eam_getAppInstances_404.1_not_found_filtered_by_appInstanceId
+  Scenario: Get a list of application instances info with a non-existing appInstanceId
+    Given there are running instances of the app
+    And the path parameter "$.appInstanceId" is set to an invalid application instance ID
+    When the request "getAppInstances" is sent
+    Then the response status code is 404
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response property "$.status" is 404
+    And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+  @eam_getAppInstances_404.2_not_found_filtered_by_appId
+  Scenario: Get a list of application instances info with a non-existing appId
+    Given the path parameter "appId" is set to a random UUID
+    When the request "getAppInstances" is sent
+    Then the response status code is 404
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response property "$.status" is 404
+    And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+  # Error 403
+  @eam_getAppInstances_403.1_missing_access_token_scope
+  Scenario: Missing access token scope
+    Given the header "Authorization" is set to an access token that does not include the required scope
+    When the request "getAppInstances" is sent
+    Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/edge-application-management-getApps.feature
+++ b/code/Test_definitions/edge-application-management-getApps.feature
@@ -23,7 +23,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operations getApps
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And A list of applications with information of them is returned
-    And the response body complies with the OAS schema at "/components/schemas/AppManifest"
+    And the response body complies with the OAS schema at "/components/schemas/AppManifestInfo"
   # Errors
   # Error 404
   @eam_getApps_404.1_apps_not_found


### PR DESCRIPTION
#### What type of PR is this?

  correction

  #### What this PR does / why we need it:

  Fixes five resource-modelling inconsistencies across apps/instances/deployments:

  - **Path naming**: renames `/appinstances` to `/app-instances`, matching the
    hyphenated kebab-case naming used by every other multi-word path
    (`/deployments`, `/clusters`, `/edge-cloud-zones`).
  - **Single-resource GET**: adds `GET /app-instances/{appInstanceId}`
    (`getAppInstance`) and `GET /deployments/{appDeploymentId}`
    (`getAppDeployment`), for consistency with `/apps`' `getApp`. The former
    list operations are renamed to `getAppInstances`/`getAppDeployments` to
    free up the singular operationId for the new by-id GETs.
  - **`Location` header consistency**: fixes `createAppInstance`'s `202`
    `Location` header, which described the URI as pointing at "the newly
    created application" (copy-paste from `/apps`) and had no working GET
    target — it now correctly describes the application instance and
    references the new `getAppInstance` endpoint. Adds an equivalent
    `Location` header to `createAppDeployment`'s `202` response, aligning it
    with `createAppInstance`'s pattern and pointing at the new
    `getAppDeployment` endpoint.
  - **Request/response schema split**: splits `AppManifest` into a
    request-only shape (no `appId`, used by `submitApp`) and a new
    `AppManifestInfo` response shape (`AppManifest` `allOf` + required
    `appId`), used by both `getApps`' list items and `getApp`.
  - **`getApp`/`getApps` shape alignment**: `getApp`'s response is unwrapped
    to return `AppManifestInfo` bare, matching `getApps`' item shape instead
    of the previous `{ appManifest: AppManifest }` wrapper.

  Additionally, now that `getAppInstance`/`getAppDeployment` exist as
  single-resource GET-by-id operations, removes the now-redundant
  `appInstanceId`/`appDeploymentId` query filters from
  `getAppInstances`/`getAppDeployments` respectively — filtering a list by
  the exact id it's supposed to enumerate is redundant with calling the
  by-id endpoint directly, and this also aligns both list operations with
  `getApps`, which has no analogous id-in-query filter.

  Test feature files were added/updated accordingly (`getAppInstance.feature`,
  `getAppDeployment.feature` new; `getAppInstances.feature`,
  `getAppDeployments.feature`, `getApp.feature`, `getApps.feature`,
  `createAppInstance.feature`, `deleteAppInstance.feature` updated).

  #### Which issue(s) this PR fixes:

  Fixes #49

  #### Special notes for reviewers:

  This is a breaking change to path/operationId naming
  (`/appinstances` → `/app-instances`, `getAppInstance` → `getAppInstances`,
  `getAppDeployments`' query params), acceptable per the issue given the API
  is still pre-1.0/rc. Reviewers should double check the `AppManifest`/
  `AppManifestInfo` split doesn't affect any other operation still relying
  on the original combined schema.

  #### Changelog input


release-note Rename /appinstances to /app-instances;

#### Additional documentation 

This section can be blank.


```
docs

```
