### PR TITLE
Fix broken regex, callback body shape, and externalDocs link (#50)

### DIFF
--- a/code/API_definitions/edge-application-management.yaml
+++ b/code/API_definitions/edge-application-management.yaml
@@ -180,8 +180,8 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 externalDocs:
-  description: Product documentation at Camara
-  url: https://github.com/camaraproject/EdgeCloud
+  description: Product documentation at CAMARA
+  url: https://github.com/camaraproject/EdgeApplicationManagement
 
 servers:
   - url: "{apiRoot}/edge-application-management/vwip"
@@ -1112,10 +1112,7 @@ components:
             content:
               application/cloudevents+json:
                 schema:
-                  type: array
-                  maxItems: 100
-                  items:
-                    $ref: "#/components/schemas/CloudEvent"
+                  $ref: "#/components/schemas/CloudEvent"
           responses:
             "204":
               description: Successful notification - No Content
@@ -1206,7 +1203,7 @@ components:
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.
-            Note: the maximum number of event types per subscription will be decided at API project level
+            Exactly one event type is required per subscription.
           type: array
           minItems: 1
           maxItems: 1
@@ -1643,7 +1640,7 @@ components:
         version:
           type: string
           maxLength: 64
-          pattern: ^v?\\d+\\.\\d+(?:\\.\\d+)?(?:[-+][0-9A-Za-z.-]+)?$
+          pattern: ^v?\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?$
           description: Kubernetes version of the cluster.
         nodePools:
           description: Node Pools in the cluster.
@@ -2111,7 +2108,7 @@ components:
           type: string
           maxLength: 64
           description: Minimum Kubernetes Version.
-          pattern: ^v?\\d+\\.\\d+(?:\\.\\d+)?(?:[-+][0-9A-Za-z.-]+)?$
+          pattern: ^v?\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?$
         additionalStorage:
           type: string
           maxLength: 32

--- a/code/API_definitions/edge-application-management.yaml
+++ b/code/API_definitions/edge-application-management.yaml
@@ -233,7 +233,7 @@ paths:
           description: Application created successfully
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -278,7 +278,7 @@ paths:
           description: List of existing applications
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -325,7 +325,7 @@ paths:
           description: Information of Application
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -371,7 +371,7 @@ paths:
           description: Request accepted
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
         "204":
           description: App deleted
         "400":
@@ -439,7 +439,7 @@ paths:
           description: Application instantiation accepted
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
             Location:
               description: Contains the URI of the newly created application.
               required: true
@@ -524,7 +524,7 @@ paths:
             parameters.
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -571,7 +571,7 @@ paths:
             deletion process
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
         "204":
           description: Application Instance Deleted
         "400":
@@ -635,7 +635,7 @@ paths:
           description: Application deployment accepted
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -708,7 +708,7 @@ paths:
             parameters.
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -756,7 +756,7 @@ paths:
             deletion process
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
@@ -871,7 +871,7 @@ paths:
           description: Application deployment updated successfully
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -946,7 +946,7 @@ paths:
             the specified query parameters.
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -1000,7 +1000,7 @@ paths:
             Available Edge Cloud Zones.
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -1036,13 +1036,6 @@ components:
         Correlation id for the different services
       schema:
         $ref: "#/components/schemas/XCorrelator"
-  headers:
-    x-correlator:
-      description: |
-        Correlation id for the different services
-      required: false
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
 
   callbacks:
     onAppInstanceStatusChange:
@@ -1076,7 +1069,7 @@ components:
               description: Successful notification - No Content
               headers:
                 x-correlator:
-                  $ref: "#/components/headers/x-correlator"
+                  $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
             "400":
               $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
             "401":
@@ -1118,7 +1111,7 @@ components:
               description: Successful notification - No Content
               headers:
                 x-correlator:
-                  $ref: "#/components/headers/x-correlator"
+                  $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
             "400":
               $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
             "401":


### PR DESCRIPTION
#### What type of PR is this?

  bug
  correction

  #### What this PR does / why we need it:

  Fixes five spec bugs identified in issue #50:

  - **Broken Kubernetes version regex**: `ClusterInfo.version` and
    `KubernetesResources.version` used a pattern with doubled backslashes
    (`\\d`, `\\.`). As an unquoted YAML scalar, no escape processing happens,
    so the pattern literally meant "a backslash, then a literal d/dot" and
    could never match a real version string like `v1.28.3`. Fixed to use
    single backslashes, consistent with every other numeric pattern in the
    file.
  - **`x-correlator`/`x-correlator-2` duplication**: the API definition kept
    its own local `components.headers.x-correlator`, separate from the
    canonical one in `../common/CAMARA_common.yaml` (already pulled in by
    the bundled `Generic4xx`/`Generic5xx` response templates). Bundling the
    spec with `redocly bundle` therefore always found two distinct source
    definitions named `x-correlator`, and Redocly's default naming strategy
    silently renamed the second one to `x-correlator-2` on every release
    snapshot. Removed the redundant local header and repointed all 15
    `$ref`s to the single canonical `CAMARA_common.yaml` definition, fixing
    the collision at the root instead of relying on the bundler's fallback.
  - **Callback body shape inconsistency**: `onAppDeploymentStatusChange`'s
    callback request body was `type: array` of `CloudEvent`, while the
    structurally identical `onAppInstanceStatusChange` used a single
    `CloudEvent`. Aligned both to a single `CloudEvent`, matching the
    `application/cloudevents+json` media type (batches use
    `application/cloudevents-batch+json` instead).
  - **Wrong `externalDocs`**: `url` pointed at the unrelated
    `camaraproject/EdgeCloud` sandbox repo instead of this API's own repo;
    `description` had incorrect capitalization ("Camara" instead of
    "CAMARA"). Both corrected per Design Guide section 5.4.
  - **Contradictory description**: `SubscriptionRequest.types`' description
    said the max number of event types "will be decided at API project
    level" while the schema already hard-coded `minItems`/`maxItems: 1`.
    Updated the description to state that exactly one event type is
    required per subscription.

  #### Which issue(s) this PR fixes:

  Fixes #50

  #### Special notes for reviewers:

  None of these were flagged by CAMARA Validation (Spectral checks pattern
  existence/type, not regex semantics or cross-file naming collisions). The
  `x-correlator-2` fix is verifiable by running `redocly bundle` on the
  corrected spec and confirming no renamed duplicate appears in the output.

  #### Changelog input


release-note Fix broken Kubernetes version regex (doubled backslashes), remove duplicate x-
correlator header causing x-correlator-2 in bundled specs, align onAppDeploymentStatusChange
callback body shape with onAppInstanceStatusChange, fix externalDocs to point at this repo, and
correct SubscriptionRequest.types description to match its cardinality.


  #### Additional documentation

  This section can be blank.


docs
