### PR TITLE
Remove "API" from info.title per Design Guide 5.3.1 (#51)

### DIFF
--- a/code/API_definitions/edge-application-management.yaml
+++ b/code/API_definitions/edge-application-management.yaml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.3
 info:
-  title: Edge Application Management API
+  title: Edge Application Management
   version: wip
   description: |
     Edge Application Management API allows API consumers to manage the


### PR DESCRIPTION
#### What type of PR is this?

  correction
  documentation

  #### What this PR does / why we need it:

  Changes `info.title` from `Edge Application Management API` to
  `Edge Application Management`, per CAMARA API Design Guide section 5.3.1
  (DG-024), which states the title field SHALL NOT include the term "API".

  `info.description` and other prose references to "Edge Application
  Management API" throughout the spec, test feature files, and documentation
  are left unchanged, since the Guide's restriction applies specifically to
  the `title` field, not to descriptive text.

  #### Which issue(s) this PR fixes:

  Fixes #51

  #### Special notes for reviewers:

  This rule (DG-024) has no current Spectral/OWASP implementation in the
  CAMARA Validation Framework, so it isn't caught by CI — verification is
  manual against the Design Guide text.

  #### Changelog input


release-note Remove "API" from info.title per Design Guide section 5.3.1 (DG-024).


  #### Additional documentation

  This section can be blank.

```
docs

```
