### PR TITLE
Fix wrong operationId sent in several .feature files (#52)

### DIFF
--- a/code/Test_definitions/edge-application-management-createAppInstance.feature
+++ b/code/Test_definitions/edge-application-management-createAppInstance.feature
@@ -24,7 +24,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppInsta
     And the request body property "$.name" is set to a valid name
     And the request body property "$.appId" is set to a valid application ID
     And the request body property "$.edgeCloudZoneId" is set to a valid edge zone id
-    When the request "createApp" is sent
+    When the request "createAppInstance" is sent
     Then the response status code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -36,7 +36,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppInsta
     And the request body property "$.appId" is set to a valid application ID
     And the request body property "$.edgeCloudZoneId" is set to a valid edge zone id
     And the request body property "$.KubernetesClusterRef" is set to a valid kubernetes cluster
-    When the request "createApp" is sent
+    When the request "createAppInstance" is sent
     Then the response status code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -50,7 +50,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppInsta
     And the request body property "$.appId" is set to a valid application ID
     And the request body property "$.edgeCloudZoneId" is set to a valid edge zone id
     And Application instance with "$.name" and "$.appId" is already running in "$.edgeCloudZoneId"
-    When the request "createApp" is sent
+    When the request "createAppInstance" is sent
     Then the response status code is 409
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"

--- a/code/Test_definitions/edge-application-management-deleteAppDeployment.feature
+++ b/code/Test_definitions/edge-application-management-deleteAppDeployment.feature
@@ -20,7 +20,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppDeplo
   Scenario: Delete a running instance of an application within an Edge Cloud Zone with mandatory parameter ("appDeploymentId")
     Given there are application instances running
     And the request path parameter "$.appDeploymentIdd" is set to a valid application ID
-    When the request "deleteApp" is sent
+    When the request "deleteAppDeployment" is sent
     Then the response status code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/edge-application-management-deleteAppInstance.feature
+++ b/code/Test_definitions/edge-application-management-deleteAppInstance.feature
@@ -20,7 +20,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppInsta
   Scenario: Delete a running instance of an application within an Edge Cloud Zone with mandatory parameter ("appInstanceId") - async
     Given there are application instances running
     And the request path parameter "$.appInstanceId" is set to a valid application ID
-    When the request "deleteApp" is sent
+    When the request "deleteAppInstance" is sent
     Then the response status code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -29,7 +29,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppInsta
   Scenario: Delete a running instance of an application within an Edge Cloud Zone with mandatory parameter ("appInstanceId") - sync
     Given there are application instances running
     And the request path parameter "$.appInstanceId" is set to a valid application ID
-    When the request "deleteApp" is sent
+    When the request "deleteAppInstance" is sent
     Then the response status code is 204
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/edge-application-management-getClusters.feature
+++ b/code/Test_definitions/edge-application-management-getClusters.feature
@@ -30,7 +30,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getClusters
   Scenario: Get information of existing clusters with optional parameters ("region")
     Given There are at least one cluster available
     And the path parameter "$.region" is set to a valid region
-    When When the request "getClusters" is sent
+    When the request "getClusters" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -41,7 +41,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getClusters
   Scenario: Get information of existing clusters with optional parameters ("edgeCloudZoneId")
     Given There are at least one cluster available
     And the path parameter "$.edgeCloudZoneId" is set to a valid edgeCloudZoneId
-    When When the request "getClusters" is sent
+    When the request "getClusters" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -52,7 +52,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getClusters
   Scenario: Get information of existing clusters with optional parameters ("clusterRef")
     Given There are at least one cluster available
     And the path parameter "$.clusterRef" is set to a valid clusterRef
-    When When the request "getClusters" is sent
+    When the request "getClusters" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -63,7 +63,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getClusters
   @eam_getClusters_404.1_not_found
   Scenario: Get information of existing clusters with invalid optional parameters ("region")
     Given the path parameter "$.region" is set to an invalid region
-    When When the request "getClusters" is sent
+    When the request "getClusters" is sent
     Then the response status code is 404
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -74,7 +74,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getClusters
   @eam_getClusters_403.1_missing_access_token_scope
   Scenario: Missing access token scope
     Given the header "Authorization" is set to an access token that does not include the required scope
-    When When the request "getClusters" is sent
+    When the request "getClusters" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/edge-application-management-getEdgeCloudZones.feature
+++ b/code/Test_definitions/edge-application-management-getEdgeCloudZones.feature
@@ -19,7 +19,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   @eam_getEdgeCloudZone_01_generic_success_scenario
   Scenario: Get information of existing edge cloud zones
     Given There are at least one Edge Cloud Zones available
-    When the request "getEdgeCloudZone" is sent
+    When the request "getEdgeCloudZones" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -30,7 +30,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   Scenario: Get information of existing Edge Cloud Zones with optional parameters ("region")
     Given There are at least one Edge Cloud Zones available
     And the path parameter "$.region" is set to a valid region
-    When When the request "getEdgeCloudZone" is sent
+    When the request "getEdgeCloudZones" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -41,7 +41,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   Scenario: Get information of existing Edge Cloud Zones with optional parameters ("status")
     Given There are at least one Edge Cloud Zones available
     And the path parameter "$.status" is set to a valid status
-    When When the request "getEdgeCloudZone" is sent
+    When the request "getEdgeCloudZones" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -52,7 +52,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   @eam_getEdgeCloudZone_404.1_not_found
   Scenario: Get information of existing Edge Cloud Zones with invalid optional parameters ("region")
     Given the path parameter "$.region" is set to an invalid region
-    When When the request "getEdgeCloudZone" is sent
+    When the request "getEdgeCloudZones" is sent
     Then the response status code is 404
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -63,7 +63,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   @eam_getEdgeCloudZone_403.1_missing_access_token_scope
   Scenario: Missing access token scope
     Given the header "Authorization" is set to an access token that does not include the required scope
-    When When the request "getEdgeCloudZone" is sent
+    When the request "getEdgeCloudZones" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/edge-application-management-updateAppDeployment.feature
+++ b/code/Test_definitions/edge-application-management-updateAppDeployment.feature
@@ -23,7 +23,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation updateAppDeplo
     Given there are application instances running
     And the request path parameter "$.appDeploymentIdd" is set to a valid application ID
     And the body property "$.appDeploymentName" is set to a valid name
-    When the request "deleteApp" is sent
+    When the request "updateAppDeployment" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"


### PR DESCRIPTION
#### What type of PR is this?

  tests

  #### What this PR does / why we need it:

  Fixes wrong `operationId` strings sent in several `Test_definitions/*.feature`
  files, where scenarios were likely cloned from `submitApp.feature`/
  `deleteApp.feature` and not fully updated:

  - `createAppInstance.feature`: `"createApp"` → `"createAppInstance"` in the
    2 success scenarios and the 409 conflict error scenario (same wrong value
    found there too, beyond what the issue listed).
  - `updateAppDeployment.feature`: `"deleteApp"` → `"updateAppDeployment"`
    in its only success scenario.
  - `deleteAppDeployment.feature`: `"deleteApp"` → `"deleteAppDeployment"`
    in its only success scenario.
  - `deleteAppInstance.feature`: `"deleteApp"` → `"deleteAppInstance"` in both
    success scenarios (async 202 and sync 204).
  - `getEdgeCloudZones.feature`: `"getEdgeCloudZone"` (singular — doesn't
    exist in the spec) → `"getEdgeCloudZones"` in all 5 scenarios; also fixed
    the duplicated `When When the request...` keyword typo present in 4 of
    those 5 scenarios.

  While auditing for the same "When When" typo pattern, also found and fixed
  an identical instance in `getClusters.feature` (5 occurrences), which
  wasn't listed in the original issue but is the same class of copy-paste
  bug. Confirmed via repo-wide search that no other `.feature` file contains
  this duplication.

  #### Which issue(s) this PR fixes:

  Fixes #52

  #### Special notes for reviewers:

  None of this was caught by the current CAMARA Validation run — cross-
  checking a Gherkin step's quoted `operationId` string against the OpenAPI
  spec is a documented gap in the Testing Guidelines audit.

  #### Changelog input


release-note


  #### Additional documentation

  This section can be blank.


docs

#### Additional documentation 

This section can be blank.



```
docs

```
