### PR TITLE
Fix phantom schemas, wrong error codes, and copy-paste bugs in feature files (#53)

### DIFF
--- a/code/Test_definitions/edge-application-management-createAppDeployment.feature
+++ b/code/Test_definitions/edge-application-management-createAppDeployment.feature
@@ -16,7 +16,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppDeplo
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
   # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
-    And the request body is set by default to a request body compliant with the schema at "/components/schemas/AppDeploymentManifest"
+    And the request body is set by default to a request body compliant with the request body schema for this operation
   # Success scenarios
   @eam_createAppDeployment_01_generic_success_scenario
   Scenario: Instantiate an Application with just mandatory parameters ("appDeploymentName", "appId" and "edgeCloudZoneId" in body)
@@ -31,12 +31,12 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppDeplo
     And the response body complies with the OAS schema for this operation and status code
     And the response body contains the "appDeploymentId"
   @eam_createAppDeployment_02_success_scenario_optional_parameters
-  Scenario: Instantiate an Application with mandatory parameters ("appDeploymentName", "appId" and "edgeCloudZoneId" in body) and optional parameter ("KubernetesClusterRef")
+  Scenario: Instantiate an Application with mandatory parameters ("appDeploymentName", "appId" and "edgeCloudZoneId" in body) and optional parameter ("kubernetesClusterRefs")
     Given an application has already been submitted by operation submitApp
     And the request body property "$.appDeploymentName" is set to a valid name
     And the request body property "$.appId" is set to a valid application ID
     And the request body property "$.edgeCloudZoneId" is set to a valid edge zone id
-    And the request body property "$.KubernetesClusterRef" is set to a valid kubernetes cluster
+    And the request body property "$.kubernetesClusterRefs" is set to a valid kubernetes cluster
     When the request "createAppDeployment" is sent
     Then the response status code is 202
     And the response header "Content-Type" is "application/json"
@@ -56,12 +56,12 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppDeplo
     Then the response status code is 409
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
-    And the response property "$.code" is "CONFLICT"
+    And the response property "$.code" is "ALREADY_EXISTS"
     And the response property "$.message" contains a user friendly text
   # Error 400
   @eam_createAppDeployment_400.1_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
-    Given the request body is set to any value which is not compliant with the schema at "/components/schemas/AppDeploymentManifest"
+    Given the request body is set to any value which is not compliant with the request body schema for this operation
     When the request "createAppDeployment" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/edge-application-management-createAppInstance.feature
+++ b/code/Test_definitions/edge-application-management-createAppInstance.feature
@@ -16,7 +16,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppInsta
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
   # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
-    And the request body is set by default to a request body compliant with the schema at "/components/schemas/AppInstanceManifest"
+    And the request body is set by default to a request body compliant with the request body schema for this operation
   # Success scenarios
   @eam_createAppInstance_01_generic_success_scenario
   Scenario: Instantiate an Application with just mandatory parameters ("name", "appId" and "edgeCloudZoneId" in body)
@@ -24,19 +24,19 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppInsta
     And the request body property "$.name" is set to a valid name
     And the request body property "$.appId" is set to a valid application ID
     And the request body property "$.edgeCloudZoneId" is set to a valid edge zone id
-    When the request "createApp" is sent
+    When the request "createAppInstance" is sent
     Then the response status code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
   @eam_createAppInstance_02_success_scenario_optional_parameters
-  Scenario: Instantiate an Application with mandatory parameters ("name", "appId" and "edgeCloudZoneId" in body) and optional parameter ("KubernetesClusterRef")
+  Scenario: Instantiate an Application with mandatory parameters ("name", "appId" and "edgeCloudZoneId" in body) and optional parameter ("kubernetesClusterRef")
     Given an application has already been submitted by operation submitApp
     And the request body property "$.name" is set to a valid name
     And the request body property "$.appId" is set to a valid application ID
     And the request body property "$.edgeCloudZoneId" is set to a valid edge zone id
-    And the request body property "$.KubernetesClusterRef" is set to a valid kubernetes cluster
-    When the request "createApp" is sent
+    And the request body property "$.kubernetesClusterRef" is set to a valid kubernetes cluster
+    When the request "createAppInstance" is sent
     Then the response status code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -50,16 +50,16 @@ Feature: CAMARA Edge Application Management API, vwip - Operation createAppInsta
     And the request body property "$.appId" is set to a valid application ID
     And the request body property "$.edgeCloudZoneId" is set to a valid edge zone id
     And Application instance with "$.name" and "$.appId" is already running in "$.edgeCloudZoneId"
-    When the request "createApp" is sent
+    When the request "createAppInstance" is sent
     Then the response status code is 409
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
-    And the response property "$.code" is "CONFLICT"
+    And the response property "$.code" is "ALREADY_EXISTS"
     And the response property "$.message" contains a user friendly text
   # Error 400
   @eam_createAppInstance_400.1_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
-    Given the request body is set to any value which is not compliant with the schema at "/components/schemas/AppInstanceManifest"
+    Given the request body is set to any value which is not compliant with the request body schema for this operation
     When the request "createAppInstance" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/edge-application-management-deleteApp.feature
+++ b/code/Test_definitions/edge-application-management-deleteApp.feature
@@ -36,7 +36,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteApp
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 409
-    And the response property "$.code" is "CONFLICT"
+    And the response property "$.code" is "ABORTED"
     And the response property "$.message" contains a user friendly text
   # Error 404
   @eam_deleteApp_404.1_invalid_parameter

--- a/code/Test_definitions/edge-application-management-deleteAppDeployment.feature
+++ b/code/Test_definitions/edge-application-management-deleteAppDeployment.feature
@@ -11,7 +11,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppDeplo
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common deleteAppDeployment setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/deployment/{appDeploymentId}"
+    And the resource "/edge-application-management/vwip/deployments/{appDeploymentId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
@@ -19,7 +19,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation deleteAppDeplo
   @eam_deleteAppDeployment_01_generic_success_scenario_async
   Scenario: Delete a running instance of an application within an Edge Cloud Zone with mandatory parameter ("appDeploymentId")
     Given there are application instances running
-    And the request path parameter "$.appDeploymentIdd" is set to a valid application ID
+    And the request path parameter "$.appDeploymentId" is set to a valid application deployment ID
     When the request "deleteApp" is sent
     Then the response status code is 202
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/edge-application-management-getAppDeployments.feature
+++ b/code/Test_definitions/edge-application-management-getAppDeployments.feature
@@ -17,44 +17,43 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppDeployme
   # Success scenarios
   @eam_getAppDeployments_01_generic_success_scenario
   Scenario: Get information of all existing application deployments
-    Given there are application deployments created by operation createAppInstance
+    Given there are application deployments created by operation createAppDeployment
     When the request "getAppDeployments" is sent
     Then the response status code is 200
     And A list of existing app deployments is returned
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with the OAS schema at "/components/schemas/AppDeploymentInfo"
+    And the response body is an array complying with the OAS schema at "/components/schemas/AppDeploymentInfo"
   @eam_getAppDeployments_02_success_scenario_filtered_by_appId
-  Scenario: Get application deployments info with mandatory parameter ("appId")
-    Given there are application deployments created by operation createAppInstance
-    And the request path parameter "$.appId" is set to a valid application ID
+  Scenario: Get application deployments info with optional query parameter ("appId")
+    Given there are application deployments created by operation createAppDeployment
+    And the request query parameter "$.appId" is set to a valid application ID
     When the request "getAppDeployments" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And information of all existing app deployments of given app is returned
-    And the response body complies with the OAS schema at "/components/schemas/AppDeploymentInfo"
-  @eam_getAppDeployments_03_success_scenario_filtered_by_appInstanceId
-  Scenario: Get application deployments info with mandatory parameter ("appInstanceId")
-    Given there are application deployments created by operation createAppInstance
-    And the request path parameter "$.appInstanceId" is set to a valid application ID
+    And the response body is an array complying with the OAS schema at "/components/schemas/AppDeploymentInfo"
+  @eam_getAppDeployments_03_success_scenario_filtered_by_appDeploymentId
+  Scenario: Get application deployments info with optional query parameter ("appDeploymentId")
+    Given there are application deployments created by operation createAppDeployment
+    And the request query parameter "$.appDeploymentId" is set to a valid application deployment ID
     When the request "getAppDeployments" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And information of all existing app deployments of given app is returned
-    And the response body complies with the OAS schema at "/components/schemas/AppDeploymentInfo"
-    And the response property "$name" has the value provided for createAppInstance
-    And the response property "$appId" has the value provided for createAppInstance
-    And the response property "$appInstanceId" has the value provided for createAppInstance and used as path parameter
-    And the response property "$appProvider" has the value provided for createAppInstance
-    And the response property "$edgeCloudZoneId" has the value provided for createAppInstance
+    And the response body is an array complying with the OAS schema at "/components/schemas/AppDeploymentInfo"
+    And the response property "$appDeploymentName" has the value provided for createAppDeployment
+    And the response property "$appId" has the value provided for createAppDeployment
+    And the response property "$appDeploymentId" has the value provided for createAppDeployment and used as query parameter
+    And the response property "$edgeCloudZones" has the value provided for createAppDeployment
   # Errors
   # Error 404
-  @eam_getAppDeployments_404.1_not_found_filtered_by_appInstanceId
-  Scenario: Get a list of application deployments info with a non-existing appInstanceId
+  @eam_getAppDeployments_404.1_not_found_filtered_by_appDeploymentId
+  Scenario: Get a list of application deployments info with a non-existing appDeploymentId
     Given there are running deployments of the app
-    And the path parameter "$.appInstanceId" is set to an invalid application instance ID
+    And the query parameter "$.appDeploymentId" is set to an invalid application deployment ID
     When the request "getAppDeployments" is sent
     Then the response status code is 404
     And the response header "Content-Type" is "application/json"
@@ -64,7 +63,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppDeployme
     And the response property "$.message" contains a user friendly text
   @eam_getAppDeployments_404.2_not_found_filtered_by_appId
   Scenario: Get a list of application deployments info with a non-existing appId
-    Given the path parameter "appId" is set to a random UUID
+    Given the query parameter "appId" is set to a random UUID
     When the request "getAppDeployments" is sent
     Then the response status code is 404
     And the response header "Content-Type" is "application/json"
@@ -86,8 +85,8 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppDeployme
   # Error 410
   @eam_getAppDeployments_410.1_gone
   Scenario: Get information of a removed app deployment
-    Given app instance with "$.appDeploymentId" was removed by removeAppDeployment operation
-    And the request path parameter "$.appDeploymentId" is set to an already removed removeAppDeployment Id
+    Given app deployment with "$.appDeploymentId" was removed by deleteAppDeployment operation
+    And the request query parameter "$.appDeploymentId" is set to an already removed appDeploymentId
     When the request "getAppDeployments" is sent
     Then the response status code is 410
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/edge-application-management-getAppInstance.feature
+++ b/code/Test_definitions/edge-application-management-getAppInstance.feature
@@ -23,48 +23,48 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
     And A list of existing app instances is returned
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+    And the response body is an array complying with the OAS schema at "/components/schemas/AppInstanceInfo"
   @eam_getAppInstance_02_success_scenario_filtered_by_appId
-  Scenario: Get application instances info with mandatory parameter ("appId")
+  Scenario: Get application instances info with optional query parameter ("appId")
     Given there are application instances created by operation createAppInstance
-    And the request path parameter "$.appId" is set to a valid application ID
+    And the request query parameter "$.appId" is set to a valid application ID
     When the request "getAppInstance" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And information of all existing app instances of given app is returned
-    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+    And the response body is an array complying with the OAS schema at "/components/schemas/AppInstanceInfo"
   @eam_getAppInstance_03_success_scenario_filtered_by_appInstanceId
-  Scenario: Get application instances info with mandatory parameter ("appInstanceId")
+  Scenario: Get application instances info with optional query parameter ("appInstanceId")
     Given there are application instances created by operation createAppInstance
-    And the request path parameter "$.appInstanceId" is set to a valid application ID
+    And the request query parameter "$.appInstanceId" is set to a valid application instance ID
     When the request "getAppInstance" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And information of all existing app instances of given app is returned
-    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+    And the response body is an array complying with the OAS schema at "/components/schemas/AppInstanceInfo"
     And the response property "$name" has the value provided for createAppInstance
     And the response property "$appId" has the value provided for createAppInstance
-    And the response property "$appInstanceId" has the value provided for createAppInstance and used as path parameter
+    And the response property "$appInstanceId" has the value provided for createAppInstance and used as query parameter
     And the response property "$appProvider" has the value provided for createAppInstance
     And the response property "$edgeCloudZoneId" has the value provided for createAppInstance
   @eam_getAppInstance_04_success_scenario_filtered_by_region
-  Scenario: Get application instances info with mandatory parameter ("region")
+  Scenario: Get application instances info with optional query parameter ("region")
     Given there are application instances created by operation createAppInstance
-    And the request path parameter "$.region" is set to a valid application ID
+    And the request query parameter "$.region" is set to a valid region
     When the request "getAppInstance" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And information of all existing app instances running in the specified region is returned
-    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+    And the response body is an array complying with the OAS schema at "/components/schemas/AppInstanceInfo"
   # Errors
   # Error 404
   @eam_getAppInstance_404.1_not_found_filtered_by_appInstanceId
   Scenario: Get a list of application instances info with a non-existing appInstanceId
     Given there are running instances of the app
-    And the path parameter "$.appInstanceId" is set to an invalid application instance ID
+    And the query parameter "$.appInstanceId" is set to an invalid application instance ID
     When the request "getAppInstance" is sent
     Then the response status code is 404
     And the response header "Content-Type" is "application/json"
@@ -74,7 +74,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
     And the response property "$.message" contains a user friendly text
   @eam_getAppInstance_404.2_not_found_filtered_by_appId
   Scenario: Get a list of application instances info with a non-existing appId
-    Given the path parameter "appId" is set to a random UUID
+    Given the query parameter "appId" is set to a random UUID
     When the request "getAppInstance" is sent
     Then the response status code is 404
     And the response header "Content-Type" is "application/json"
@@ -92,17 +92,4 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getAppInstance
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
-    And the response property "$.message" contains a user friendly text
-  # Error 410
-  #/deployments	GET	410
-  @eam_getAppInstance_410.1_gone
-  Scenario: Get information of a removed app instance
-    Given app instance with "$.appDeploymentId" was removed by removeAppInstance operation
-    And the request path parameter "$.appDeploymentId" is set to an already removed appInstance Id
-    When the request "getAppInstance" is sent
-    Then the response status code is 410
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response header "Content-Type" is "application/json"
-    And the response property "$.status" is 410
-    And the response property "$.code" is "GONE"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/edge-application-management-getEdgeCloudZones.feature
+++ b/code/Test_definitions/edge-application-management-getEdgeCloudZones.feature
@@ -29,7 +29,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   @eam_getEdgeCloudZone_02_generic_success_scenario_filtered_by_region
   Scenario: Get information of existing Edge Cloud Zones with optional parameters ("region")
     Given There are at least one Edge Cloud Zones available
-    And the path parameter "$.region" is set to a valid region
+    And the request query parameter "$.region" is set to a valid region
     When When the request "getEdgeCloudZone" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
@@ -40,7 +40,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   @eam_getEdgeCloudZone_03_generic_success_scenario_filtered_by_status
   Scenario: Get information of existing Edge Cloud Zones with optional parameters ("status")
     Given There are at least one Edge Cloud Zones available
-    And the path parameter "$.status" is set to a valid status
+    And the request query parameter "$.status" is set to a valid status
     When When the request "getEdgeCloudZone" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
@@ -51,7 +51,7 @@ Feature: CAMARA Edge Application Management API, vwip - Operation getEdgeCloudZo
   #/edge-cloud-zones	GET	404
   @eam_getEdgeCloudZone_404.1_not_found
   Scenario: Get information of existing Edge Cloud Zones with invalid optional parameters ("region")
-    Given the path parameter "$.region" is set to an invalid region
+    Given the query parameter "$.region" is set to an invalid region
     When When the request "getEdgeCloudZone" is sent
     Then the response status code is 404
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/edge-application-management-submitApp.feature
+++ b/code/Test_definitions/edge-application-management-submitApp.feature
@@ -22,12 +22,12 @@ Feature: CAMARA Edge Application Management API, vwip - Operation submitApp
   # Valid testing device and default request body compliant with the schema
     Given A valid application to be submitted
     And the request body property "$.name" is set to a valid name
-    And the request body property "$.appPorvider" is set to a application provider
+    And the request body property "$.appProvider" is set to a application provider
     And the request body property "$.version" is set to a valid version
     And the request body property "$.packageType" is set to a valid package type
     And the request body property "$.appRepo" is set to a valid repository
     And the request body property "$.requiredResources" is set to a valid required resources object
-    And the request body property "$.componentSpect" is set to a valid object
+    And the request body property "$.componentSpec" is set to a valid object
     When the request "submitApp" is sent
     Then the response status code is 201
     And the response header "Content-Type" is "application/json"
@@ -38,14 +38,14 @@ Feature: CAMARA Edge Application Management API, vwip - Operation submitApp
   # Error 409
   @eam_submitApp_409.1_conflict
   Scenario: Error response when an application is already submitted
-    Given an AppManifest request body referencing an already submitted application
+    Given a request body referencing an already submitted application
     And the request body property "$.name" is set to an existing application name
     And the request body property "$.version" is set to the same version of the existing application
-    When invoking with the POST method to submit an app with all required parameters
+    When the request "submitApp" is sent
     Then the response status code is 409
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
-    And the response property "$.code" is "CONFLICT"
+    And the response property "$.code" is "ALREADY_EXISTS"
     And the response property "$.message" contains a user friendly text
   # Error 400
   @eam_submitApp_400.1_schema_not_compliant

--- a/code/Test_definitions/edge-application-management-updateAppDeployment.feature
+++ b/code/Test_definitions/edge-application-management-updateAppDeployment.feature
@@ -11,23 +11,23 @@ Feature: CAMARA Edge Application Management API, vwip - Operation updateAppDeplo
   # References to OAS spec schemas refer to schemas specified in edge-application-management.yaml
   Background: Common updateAppDeployment setup
     Given an environment at "apiRoot"
-    And the resource "/edge-application-management/vwip/deployment/{appDeploymentId}"
+    And the resource "/edge-application-management/vwip/deployments/{appDeploymentId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
   # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
-    And the request body is set by default to a request body compliant with the schema at "/components/schemas/AppDeploymentManifest"
+    And the request body is set by default to a request body compliant with the request body schema for this operation
   # Success scenarios
   @eam_updateAppDeployment_01_generic_success_scenario
   Scenario: Update a running instance of an application within an Edge Cloud Zone with mandatory parameter ("appDeploymentId")
     Given there are application instances running
-    And the request path parameter "$.appDeploymentIdd" is set to a valid application ID
+    And the request path parameter "$.appDeploymentId" is set to a valid application deployment ID
     And the body property "$.appDeploymentName" is set to a valid name
     When the request "deleteApp" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with the OAS schema at "/components/schemas/AppInstanceInfo"
+    And the response body complies with the OAS schema at "/components/schemas/AppDeploymentInfo"
   # Errors
   # Error 404
   @eam_updateAppDeployment_404.1_invalid_parameter


### PR DESCRIPTION
#### What type of PR is this?

  tests

  #### What this PR does / why we need it:

  Fixes multiple test bugs in `Test_definitions/*.feature` files where Gherkin
  steps reference schemas, parameters, operations, or error codes that don't
  match the OpenAPI spec:

  1. **Phantom schema references** — `createAppInstance.feature`,
     `createAppDeployment.feature`, and `updateAppDeployment.feature`
     referenced nonexistent components (`AppInstanceManifest`,
     `AppDeploymentManifest`); the actual request bodies are anonymous inline
     object schemas. Replaced with generic "request body schema for this
     operation" phrasing.
  2. **Query parameters mislabeled as path parameters** — `appId`,
     `appInstanceId`, `region` (`getAppInstance.feature`), `appId`,
     `appDeploymentId` (`getAppDeployments.feature`), and `region`, `status`
     (`getEdgeCloudZones.feature`) are all `in: query` in the spec but were
     described as "path parameter". Also fixed a copy-pasted `region`
     scenario that said "a valid application ID" instead of "a valid region".
  3. **Non-existent operation names** — `removeAppInstance`/
     `removeAppDeployment` (don't exist) corrected to
     `deleteAppInstance`/`deleteAppDeployment`.
  4. **Invalid `410` scenario removed** from `getAppInstance.feature` —
     `GET /appinstances` doesn't document `410` at all; the scenario was
     copied from the deployments feature file and never adapted (wrong
     entity id, nonexistent operation, leftover comment from the other file).
  5. **Invalid query filter** — `getAppDeployments.feature` filtered by
     `appInstanceId`, which isn't a valid query parameter for
     `GET /deployments` (only `appId`/`appDeploymentId` are); replaced with
     a proper `appDeploymentId` filter scenario, and fixed several
     `createAppInstance`-labeled steps that should have said
     `createAppDeployment`.
  6. **Deprecated/wrong error codes** — `CONFLICT` (deprecated per the
     Design Guide) asserted in `submitApp`, `createAppInstance`, and
     `createAppDeployment`'s `409` scenarios; corrected to `ALREADY_EXISTS`,
     matching the spec's own examples. `deleteApp.feature` corrected to
     `ABORTED`, also matching its spec example.
  7. **Miscellaneous typos**: `appPorvider`→`appProvider`,
     `componentSpect`→`componentSpec`, non-standard step phrasing in
     `submitApp.feature`; PascalCase `KubernetesClusterRef` corrected to the
     spec's actual `kubernetesClusterRef`/`kubernetesClusterRefs`; singular
     `/deployment/{appDeploymentId}` path corrected to plural
     `/deployments/{appDeploymentId}`; `appDeploymentIdd` typo; wrong
     `AppInstanceInfo` schema in `updateAppDeployment.feature` corrected to
     `AppDeploymentInfo`; list-response scenarios in `getAppInstance.feature`
     and `getAppDeployments.feature` corrected to assert against an array of
     the schema instead of a bare object.

  **Out of scope / left untouched:** the wrong singular `getEdgeCloudZone`
  operationId, the `"When When the request..."` typo, and the wrong
  `deleteApp`/`createApp` operationIds referenced in
  `updateAppDeployment.feature`, `deleteAppDeployment.feature`, and
  `createAppInstance.feature` — these are already covered by issue #52's fix
  in a separate branch/PR.

  #### Which issue(s) this PR fixes:

  Fixes #53

  #### Special notes for reviewers:

  **This PR has two merge-order dependencies on other open PRs. Both were
  verified with an actual local merge simulation (not just static analysis),
  and real Git conflicts were confirmed in both cases:**

  **1. PR #56 (fixes #48)** removes `410` from `getAppDeployments`,
  `deleteAppDeployment`, and `updateAppDeployment` (replacing it with `404`
  on the GET, and simply dropping it where `404` already existed on the
  other two). This PR intentionally left the three corresponding
  `@eam_*_410.1_gone` scenarios untouched, since as of this branch's base the
  spec still documents `410` for those operations. Once #56 merges, those
  three scenarios will test an error code that no longer exists there and
  should be removed or converted to `404` as follow-up.

  **2. PR #58 (fixes #49)** repurposes `getAppInstance.feature` from the
  *list* operation (`GET /appinstances`) to a new *by-id* operation
  (`GET /app-instances/{appInstanceId}`), moving the list scenarios into a
  new `getAppInstances.feature` file, and removes `getAppDeployments`'
  `appDeploymentId` query filter entirely (since it becomes redundant with
  a new `getAppDeployment` by-id endpoint). This **directly conflicts** with
  this PR's changes:
     - `getAppInstance.feature`: this PR fixes it as the *list* operation
       (query-param labels, array-schema assertion, removed invalid `410`
       scenario); after #58, that content semantically belongs in
       `getAppInstances.feature` instead, and `getAppInstance.feature` will
       mean something entirely different (by-id).
     - `getAppDeployments.feature`: this PR *adds* a "filtered by
       `appDeploymentId`" scenario (replacing the invalid `appInstanceId`
       one); #58 *removes* that same filter as redundant with its new
       by-id endpoint — the two changes are directly opposed.

  **Recommendation:** merge #58 (and ideally #56) first, then rebase/redo
  this PR's `getAppInstance.feature` and `getAppDeployments.feature` fixes
  against the post-#58 file layout (i.e., apply the equivalent fixes to
  `getAppInstances.feature` instead of `getAppInstance.feature`, and drop the
  now-redundant `appDeploymentId` filter addition). The other 7 files touched
  by this PR (`submitApp`, `deleteApp`, `createAppInstance`,
  `createAppDeployment`, `deleteAppDeployment`, `updateAppDeployment`,
  `getEdgeCloudZones`) are unaffected by either #56 or #58 and can land
  independently.

  #### Changelog input


release-note


  #### Additional documentation

  This section can be blank.


docs
